### PR TITLE
Add whitelist feature

### DIFF
--- a/autoload/xolox/easytags.vim
+++ b/autoload/xolox/easytags.vim
@@ -164,6 +164,10 @@ function! xolox#easytags#autoload(event) " {{{2
 endfunction
 
 function! xolox#easytags#update(silent, filter_tags, filenames) " {{{2
+  if xolox#easytags#update#pass_whitelist() != 1
+    return 0
+  endif
+
   let async = xolox#misc#option#get('easytags_async', 0)
   call g:xolox#easytags#update_timer.start()
   try

--- a/autoload/xolox/easytags/update.vim
+++ b/autoload/xolox/easytags/update.vim
@@ -262,6 +262,22 @@ function! xolox#easytags#update#foldcase_compare(a, b) " {{{1
   return a == b ? 0 : a ># b ? 1 : -1
 endfunction
 
+function! xolox#easytags#update#pass_whitelist() " {{{1
+    if !exists('g:easytags_whitelist') || empty(g:easytags_whitelist)
+        return 1
+    endif
+
+    let current_dir = getcwd()
+    for white_reg in g:easytags_whitelist
+        call xolox#misc#msg#debug("easytags.vim %s: Test '%s' with '%s'.", g:xolox#easytags#version, current_dir, white_reg)
+        if match(current_dir, white_reg) != -1
+            return 1
+        endif
+    endfor
+
+  return 0
+endfunction  "}}}
+
 function! s:create_cache() " {{{1
   let cache = {'canonicalize_cache': {}, 'exists_cache': {}}
   function cache.canonicalize(pathname) dict


### PR DESCRIPTION
Running ctags -R under home directory is so annoying. It's literally
endless. So I'm adding this whitelist feature.

Usage:

Add global variable g:easytags_whitelist. g:easytags_whitelist is an
array containing regular expressions.

For example, following statement makes easytags run only under path
containing the string "workspace", such as ~/workspace/vim-easytags
    let g:easytags_whitelist = ['workspace']